### PR TITLE
Add tap installation, standardize call reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
-A Ruby script that creates a dependency graph of installed or all available Homebrew formulae. The currently supported output options are *Dot* and *GraphML*. The Homebrew distribution contains a similar, [script][1] written in Python which describes the dependency graph in the Dot language.
+# brew-graph
+
+`brew-graph` is a Ruby script that creates a dependency graph of installed or all available Homebrew formulae. The currently supported output options are *Dot* and *GraphML*.
+
+### Installation
+
+You can install `brew-graph` using the [tap repository](https://github.com/martido/homebrew-brew-graph): 
+
+    brew install martido/brew-graph/brew-graph
+
+Alternatively, simply place `brew-graph.rb` somewhere in your `$PATH` as `brew-graph`.
 
 ## Usage
-Type `ruby brew-graph.rb -h` to display a list of available options.
-        
+
+If you installed using the above instructions, you can simply execute `brew graph -h` to see options.
+
+If within this repository directory, type `ruby brew-graph.rb -h` to display the options. 
+
 ## Requirements
 You can use Graphviz to visualize Dot graphs.
 
     brew install graphviz
-    brew-graph | dot -Tsvg -odependency_graph.svg
+    brew graph | dot -Tsvg -odependency_graph.svg
     open dependency_graph.svg
 
-You can use the [yEd][2] graph editor to visualize GraphML markup. The created markup uses yFiles's extensions to GraphML and heavily relies on defaults to keep the output reasonably small. It contains no layout information because yEd already provides an exhaustive set of algorithms.
+You can use the [yEd][1] graph editor to visualize GraphML markup. The created markup uses yFiles's extensions to GraphML and heavily relies on defaults to keep the output reasonably small. It contains no layout information because yEd already provides an exhaustive set of algorithms.
 
-[1]: https://github.com/mxcl/homebrew/blob/master/Library/Contributions/examples/brew-graph
-[2]: http://www.yworks.com/en/products_yed_about.html
+[1]: http://www.yworks.com/en/products_yed_about.html


### PR DESCRIPTION
Also removes reference to brew-graph command previously included in Homebrew, because it no longer exists as of September 2014!
