### PR TITLE
Use full name for dependencies

### DIFF
--- a/cmd/brew-graph.rb
+++ b/cmd/brew-graph.rb
@@ -168,8 +168,8 @@ See brew graph --help.}
       type = include_casks ? nil : '--formulae'
 
       case arg
-        when :all then %x[brew deps --1 --all #{type}]
-        when :installed then %x[brew deps --1 --installed #{type}]
+        when :all then %x[brew deps --1 --full-name --all #{type}]
+        when :installed then %x[brew deps --1 --full-name --installed #{type}]
         else # Treat arg as a list of formulae
           res = {}
           brew_deps_formulae(res, arg.join(' '))


### PR DESCRIPTION
This ensures that the formulae and their dependencies use the same name
ensuring that the graph is consistent.  For example, specific versions
of packages ('python' vs. 'python@3.9') or packages from third party
taps ('avr-binutils' vs. 'osx-cross/avr/avr-binutils') would otherwise
show appear as distinct nodes.